### PR TITLE
Added PHP 7.1 to 7.4 to Travis-CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 php:
   - "5.6"
   - "7.0"
+  - "7.1"
+  - "7.2"
+  - "7.3"
+  - "7.4"
   - "hhvm"
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "require": {
     "php": ">=5.4",
     "symfony/console": "^2|^3|^4",
-    "zendframework/zend-code": "~2"
+    "zendframework/zend-code": "~3"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2",


### PR DESCRIPTION
This PR adds the rest of PHP 7.x family to the build matrix.

Closes #17 